### PR TITLE
Remove extra setting of const variable

### DIFF
--- a/Arduino_Code/Arduino_Code.ino
+++ b/Arduino_Code/Arduino_Code.ino
@@ -19,7 +19,6 @@ Requirements: Sketch->Include->Manage Libraries:
 
 const byte OLED = 1;                    // Turn on/off the OLED [1,0] (Set to 0 to improve time)
 const byte LED  = 1;                    // Turn on/off the LED delay [1,0] (Set to 0 to improve time)
-const byte LED  = 0;                    // Turn on/off the LED delay [1,0] (Set to 0 to improve time)
 const int SIGNAL_THRESHOLD = 20;        // Min threshold to trigger on
 const int RESET_THRESHOLD = 12;          // Threshold to reset for next trigger
 const int LED_BRIGHTNESS = 255;          // Change the brightness on the LED [0-255]. 5 is a dim value.


### PR DESCRIPTION
Defining this twice would cause a compiler error.